### PR TITLE
fix unused variable in operators.go

### DIFF
--- a/src/chapter3/operators/operators.go
+++ b/src/chapter3/operators/operators.go
@@ -59,8 +59,8 @@ func main() {
 
 	//<start id="logicalnot"/>
 	verifiedPhone := false
-	if !verifiedEmail  {
-		fmt.Println("Display email verification reminder.")
+	if !verifiedPhone  {
+		fmt.Println("Display phone verification reminder.")
 	}
 	//<end id="logicalnot"/>
 


### PR DESCRIPTION
operators.go doesn't compile due to verifiedPhone not being used. Enjoying the book so far - thanks for putting this out!
