### PR TITLE
Modify shutdown in semaphore.go to work at any number of arguments

### DIFF
--- a/chapter6/patterns/semaphore/semaphore.go
+++ b/chapter6/patterns/semaphore/semaphore.go
@@ -117,7 +117,7 @@ func start(name string, maxReads int, maxReaders int) *readerWriter {
 func shutdown(readerWriters ...*readerWriter) {
 	// Create a WaitGroup to track the shutdowns.
 	var waitShutdown sync.WaitGroup
-	waitShutdown.Add(2)
+	waitShutdown.Add(len(readerWriters))
 
 	// Launch each call to the stop method as a goroutine.
 	for _, readerWriter := range readerWriters {


### PR DESCRIPTION
Because shutdown in semaphore.go worked only at two arguments, I modified it to work at any number of arguments.
