### PR TITLE
Consider using valid package paths

### DIFF
--- a/chapter2/sample/main.go
+++ b/chapter2/sample/main.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"os"
 
-	_ "github.com/goinaction/code/chapter2/sample/matchers"
-	"github.com/goinaction/code/chapter2/sample/search"
+	_ "./matchers"
+	"./search"
 )
 
 // init is called prior to main.

--- a/chapter2/sample/matchers/rss.go
+++ b/chapter2/sample/matchers/rss.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/goinaction/code/chapter2/sample/search"
+	"../search"
 )
 
 type (


### PR DESCRIPTION
Checking out the [free sample chapter](https://www.manning.com/books/go-in-action) I tried running the example code in Chapter 2, which in its current state errors out with:

`
main.go:7:2: cannot find package "github.com/goinaction/code/chapter2/sample/matchers" in any of:
	/usr/local/go/src/github.com/goinaction/code/chapter2/sample/matchers (from $GOROOT)
	($GOPATH not set)
main.go:8:2: cannot find package "github.com/goinaction/code/chapter2/sample/search" in any of:
	/usr/local/go/src/github.com/goinaction/code/chapter2/sample/search (from $GOROOT)
	($GOPATH not set)
`

It seems ideal for the example code to run without needing to be edited. This pull request only updates the code for Chapter 2, though it seems like it would make sense to update the other example code as well.

Thanks!