### PR TITLE
Fix typo in chapter7/patterns/search/searchers.go

### DIFF
--- a/chapter7/patterns/search/searchers.go
+++ b/chapter7/patterns/search/searchers.go
@@ -1,4 +1,4 @@
-// Package search : seachers.go contains all the different implementations
+// Package search : searchers.go contains all the different implementations
 // for the existing searchers.
 package search
 


### PR DESCRIPTION
Fix typo in chapter7/patterns/search/searchers.go