### PR TITLE
Use direct reference to a matcher from the closure, because it's safe.

### DIFF
--- a/chapter2/sample/search/search.go
+++ b/chapter2/sample/search/search.go
@@ -35,10 +35,10 @@ func Run(searchTerm string) {
 		}
 
 		// Launch the goroutine to perform the search.
-		go func(matcher Matcher, feed *Feed) {
+		go func(feed *Feed) {
 			Match(matcher, feed, searchTerm, results)
 			waitGroup.Done()
-		}(matcher, feed)
+		}(feed)
 	}
 
 	// Launch a goroutine to monitor when all the work is done.


### PR DESCRIPTION
While passing `feed` onto each goroutine stack makes sense because this
variable is reused during each for-iteration, doing the same for matcher
is redundant. This variable is created on each for-iteration, and thus
is safe: https://play.golang.org/p/83Y4sGhFpd3

In the Go play example above vet complaints only about case when feed is
captured, closing over the matcher is fine.