### PR TITLE
Add go.mod and replaces actions to get go 1.18 to compile (and run).

### DIFF
--- a/chapter2/sample/.idea/.gitignore
+++ b/chapter2/sample/.idea/.gitignore
@@ -1,0 +1,9 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+aws.xml

--- a/chapter2/sample/.idea/modules.xml
+++ b/chapter2/sample/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/sample.iml" filepath="$PROJECT_DIR$/.idea/sample.iml" />
+    </modules>
+  </component>
+</project>

--- a/chapter2/sample/.idea/sample.iml
+++ b/chapter2/sample/.idea/sample.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/chapter2/sample/.idea/vcs.xml
+++ b/chapter2/sample/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/chapter2/sample/go.mod
+++ b/chapter2/sample/go.mod
@@ -1,0 +1,17 @@
+// https://go.dev/ref/mod
+// https://go.dev/doc/modules/gomod-ref
+// https://www.digitalocean.com/community/tutorials/how-to-use-go-modules
+// https://thewebivore.com/using-replace-in-go-mod-to-point-to-your-local-module/
+
+module sample
+go 1.18
+
+replace github.com/goinaction/code/chapter2/sample/matchers => ./matchers
+replace github.com/goinaction/code/chapter2/sample/search => ./search
+require (
+	github.com/goinaction/code/chapter2/sample/matchers v1.0.0
+)
+require (
+	github.com/goinaction/code/chapter2/sample/search v1.0.0
+)
+

--- a/chapter2/sample/matchers/go.mod
+++ b/chapter2/sample/matchers/go.mod
@@ -1,0 +1,2 @@
+module matchers
+go 1.18

--- a/chapter2/sample/search/go.mod
+++ b/chapter2/sample/search/go.mod
@@ -1,0 +1,2 @@
+module search
+go 1.18


### PR DESCRIPTION
go.mod appears to be needed to compile the chapter2 sample, at least without downloading matchers and search independently in ways I don't yet understand. So figured out how to `replace` the imports in `main.go` with local directories mostly through examples and cut and paste. I don't exactly know what I'm doing, but I'll let you cherrypick what changes you want, if any.