### PR TITLE
chapter 5: notify method has pointer receiver

### DIFF
--- a/chapter5/listing36/listing36.go
+++ b/chapter5/listing36/listing36.go
@@ -29,7 +29,7 @@ func main() {
 	// Create a value of type User and send a notification.
 	u := user{"Bill", "bill@email.com"}
 
-	sendNotification(u)
+	sendNotification(&u)
 
 	// ./listing36.go:32: cannot use u (type user) as type
 	//                     notifier in argument to sendNotification:


### PR DESCRIPTION
Hi codeowners, 
Can you please review this PR, this is to fix the error in
./listing36.go:32: cannot use u (type user) as type
notifier in argument to sendNotification:
user does not implement notifier
(notify method has pointer receiver)
